### PR TITLE
Replace fake "Sarah Johnson" testimonial with founder callout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -689,22 +689,21 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Testimonial Section */}
+        {/* Founder Note Section */}
         <section className="w-full py-24 md:py-32 bg-muted/30">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto text-center">
-              <blockquote className="text-2xl md:text-3xl font-medium leading-relaxed italic mb-8">
-                "We used to wait weeks for financial reports. Now we know by lunch if yesterday made money."
-              </blockquote>
-              <div className="flex items-center justify-center gap-4">
-                <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
-                  <span className="text-lg font-semibold text-primary">SJ</span>
-                </div>
-                <div className="text-left">
-                  <p className="font-semibold">Sarah Johnson</p>
-                  <p className="text-sm text-muted-foreground">Multi-Unit Operator — Chicago</p>
-                </div>
-              </div>
+              <p className="text-sm font-medium text-primary tracking-wide uppercase mb-6">
+                From the Founder
+              </p>
+              <h2 className="text-3xl md:text-4xl font-bold tracking-tight mb-6">
+                Built by an operator running the same kind of shop you are.
+              </h2>
+              <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
+                Our founder runs a Cold Stone Creamery / Wetzel&apos;s Pretzels co-brand
+                in San Antonio. Every feature in EasyShiftHQ has to survive a weekend at
+                his store before it ships to you. If it can&apos;t, it doesn&apos;t.
+              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## What this PR does
Removes the fabricated "Sarah Johnson" testimonial from the homepage and replaces it with a founder-accountability statement crediting the Cold Stone Creamery / Wetzel's Pretzels co-brand in San Antonio as the live test bed for every shipped feature.

## Why
P0 from the 2026-05-07 growth audit: a placeholder testimonial is a credibility leak. Take it down before any paid traffic lands on the homepage. See `easyshifthq/claude-code-briefs/landing-page-batch-1.md` (PR 1).

## Verification
- [x] `pnpm build` passes — homepage rebuilds, `/` is 3.58 kB / 127 kB First Load JS
- [ ] `pnpm lint` — repo currently has no ESLint config committed, so `next lint` prompts to set one up. No regression introduced (this PR doesn't touch lint config). Recommend a follow-up to add a strict ESLint config so the verification step in future PRs is meaningful.
- [x] Section visually fits in the same outer `<section className="w-full py-24 md:py-32 bg-muted/30">` slot, immediately before the Contact / CTA section
- [x] Sarah Johnson block entirely removed (verified via diff: 1 file changed, +12 / -13)

## Notes for review
- Copy is verbatim from the brief — apostrophes use `&apos;` to avoid React JSX warnings.
- This PR is independent of PRs 2–5 in the batch and can merge in any order.

## Reference
- Brief: `easyshifthq/claude-code-briefs/landing-page-batch-1.md` (PR 1)
- Site audit: `easyshifthq/site-audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homepage now features a new "From the Founder" section sharing the founder's background in restaurant operations and how real operator experience shaped EasyShiftHQ's development.

* **Updates**
  * Testimonial section has been replaced to feature founder messaging on the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->