### PR TITLE
feat: add Capterra public-listing cross-links in footer + pricing

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Header } from "@/components/header"
 import { Footer } from "@/components/footer"
+import { SocialProofRow } from "@/components/social-proof"
 
 export const metadata: Metadata = {
   title: "Pricing",
@@ -241,6 +242,13 @@ export default function PricingPage() {
                     <p className="mt-4 text-muted-foreground leading-relaxed">{item.a}</p>
                   </details>
                 ))}
+              </div>
+
+              <div className="max-w-3xl mx-auto mt-16 pt-8 border-t border-border/50">
+                <p className="text-center text-xs text-muted-foreground mb-3 tracking-wide uppercase">
+                  Independently listed
+                </p>
+                <SocialProofRow variant="compact" />
               </div>
             </div>
           </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { TrialCTA } from "@/components/trial-cta"
+import { SocialProofRow } from "@/components/social-proof"
 import Image from "next/image"
 
 const features = [
@@ -97,6 +98,10 @@ export function Footer() {
               ))}
             </ul>
           </div>
+        </div>
+
+        <div className="border-t border-border/50 mt-8 pt-8">
+          <SocialProofRow variant="compact" />
         </div>
 
         <div className="border-t border-border mt-12 pt-8 flex flex-col sm:flex-row items-center justify-between gap-4">

--- a/components/social-proof.tsx
+++ b/components/social-proof.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link"
+
+const PLATFORMS = [
+  {
+    name: "Capterra",
+    url: "https://www.capterra.com/p/10040282/EasyShiftHQ/",
+    logoLabel: "Listed on Capterra",
+  },
+  // Add G2 / Software Advice / GetApp as those listings come online
+] as const
+
+type SocialProofRowProps = {
+  variant?: "compact" | "full"
+}
+
+export function SocialProofRow({ variant = "compact" }: SocialProofRowProps) {
+  const containerClass =
+    variant === "compact"
+      ? "flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-muted-foreground"
+      : "flex flex-wrap items-center justify-center gap-6"
+
+  return (
+    <div className={containerClass}>
+      {PLATFORMS.map((p) => (
+        <Link
+          key={p.name}
+          href={p.url}
+          target="_blank"
+          rel="noopener"
+          className="inline-flex items-center gap-2 hover:text-foreground transition-colors"
+        >
+          <span className="font-medium">{p.logoLabel}</span>
+          <svg
+            className="h-3 w-3 opacity-60"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            aria-hidden="true"
+          >
+            <path d="M3 9l6-6M5 3h4v4" />
+          </svg>
+        </Link>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Cross-links the [public Capterra listing](https://www.capterra.com/p/10040282/EasyShiftHQ/) from the marketing site for (1) third-party credibility signal at the moments of highest buyer doubt — footer site-wide and the pricing-page FAQ — and (2) an outbound link to a DA-92 domain for SEO.

Intentionally light on visual weight. **No review counts. No fake stars.** Once we have ≥1 review and the Capterra vendor dashboard surfaces the badge embed code, a small follow-up PR swaps the static text for the auto-updating widget.

## What's in here

- **`components/social-proof.tsx`** — new reusable `<SocialProofRow variant="compact" | "full" />`. PLATFORMS is a `const` array; Capterra-only today, with G2 / Software Advice / GetApp slots commented in for when those listings come online.
- **Footer (`components/footer.tsx`)** — small "Listed on Capterra" row above the © line, separated by a subtle `border-border/50` divider.
- **Pricing page (`app/pricing/page.tsx`)** — same row directly under the FAQ accordion with an "Independently listed" eyebrow. Visitors who reach the FAQ are in deep evaluation mode — highest-leverage spot for the nudge.

### Anchor anatomy

`target="_blank"` + `rel="noopener"` (no `noreferrer`). Capterra needs to see the inbound referrer for partner-program reporting; `noopener` alone is enough to close the `window.opener` security hole.

## Skipped from the brief

- **Optional homepage strip** — the homepage already has the lead-magnet promo strip immediately above the footer. A third near-footer band would dilute the credibility signal (the brief explicitly warns about adding it in too many places).

## Test plan

- [ ] `localhost:3000` — footer shows "Listed on Capterra" with the small external-link icon, links to the Capterra public URL.
- [ ] `localhost:3000/pricing` — same row appears under the FAQ accordion, before the bottom CTA, with the "Independently listed" eyebrow.
- [ ] Click the link in a fresh tab — opens the Capterra listing.
- [ ] Lighthouse SEO check still green (no structured-data changes).

## Notes

- `pnpm build` passes; `/pricing` went from 2.56 kB → 2.59 kB.
- Pre-existing tsc errors (`theme-provider.tsx`, `ui/toast.tsx`, `use-toast.ts`) are unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added social proof sections displaying independent platform listings to the pricing page and footer, with external links to verified listing platforms
  * Implemented with multiple layout variants for flexible presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->