### PR TITLE
fix: address SonarQube findings on PR #15

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next"
-import Link from "next/link"
 import { TrialCTA } from "@/components/trial-cta"
 import { ArrowRight, Check, ChevronDown } from "lucide-react"
 import { Button } from "@/components/ui/button"

--- a/components/social-proof.tsx
+++ b/components/social-proof.tsx
@@ -9,9 +9,9 @@ const PLATFORMS = [
   // Add G2 / Software Advice / GetApp as those listings come online
 ] as const
 
-type SocialProofRowProps = {
+type SocialProofRowProps = Readonly<{
   variant?: "compact" | "full"
-}
+}>
 
 export function SocialProofRow({ variant = "compact" }: SocialProofRowProps) {
   const containerClass =


### PR DESCRIPTION
## Summary

Two SonarQube nits flagged after #15 merged.

- **`app/pricing/page.tsx`** — drop the dangling `import Link from "next/link"`. The earlier TrialCTA migration replaced every `<Link>` on this page, so the import was unused (S1128).
- **`components/social-proof.tsx`** — mark `SocialProofRowProps` as `Readonly<{ … }>` per Sonar's React props rule (S6759).

Two-line diff. `pnpm build` is green.